### PR TITLE
Add test that verifies that the middleware returns status 400

### DIFF
--- a/tests/integration-test.spec.ts
+++ b/tests/integration-test.spec.ts
@@ -40,4 +40,10 @@ describe('Express end to end test', () => {
     const response = await testClient.post('/users', { name: 'John', id: '12323232' });
     expect(response.status).toBe(200);
   });
+
+  it('Should return 400 when the input is invalid', async () => {
+    const response = await testClient.post('/users', { name: 'John', id: 123 },
+      { validateStatus: (status) => status === 400 });
+    expect(response.status).toBe(400);
+  });
 });


### PR DESCRIPTION
We expect the middleware to return HTTP status 400 in case of a parsing
error
