### PR TITLE
add custom error handler example

### DIFF
--- a/tests/integration-test.spec.ts
+++ b/tests/integration-test.spec.ts
@@ -47,3 +47,26 @@ describe('Express end to end test', () => {
     expect(response.status).toBe(400);
   });
 });
+
+describe('Unexpected error in handler', () => {
+
+  beforeAll(async () => {
+    shutdownServer = await initServer([faultyRoutes], serverConfig);
+  });
+
+  afterAll(async () => {
+    await shutdownServer();
+  });
+
+  const faultyRoutes = (app: Application) => {
+    app.post('/error', parsingMiddleWare(() => {
+      throw new Error('This is an unexpected error');
+    }));
+  };
+
+  it('Should return 500', async () => {
+    const response = await testClient.post('/error', { name: 'John', id: '12323232' },
+      { validateStatus: (status) => status === 500 });
+    expect(response.status).toBe(500);
+  });
+});


### PR DESCRIPTION
- Add an example of registering a custom error handling function
- Change parser argument to optional in the no input overload
- Add an example for registering a handler with no input
- Add test that validates that unexpected errors result in HTTP 500
