### PR TITLE
Add support in z.preprocess

### DIFF
--- a/src/zodExpressLite.ts
+++ b/src/zodExpressLite.ts
@@ -1,12 +1,12 @@
-import { Request, Response, RequestHandler } from 'express';
-import { ZodType, SafeParseReturnType } from 'zod';
+import { Request, RequestHandler, Response } from 'express';
+import { SafeParseReturnType, ZodType, ZodTypeDef } from 'zod';
 
 type UnexpectedErrorHandler = (error: Error, req: Request, res: Response) => void
 type CustomParsingFunction<O> = (request: Request) => SafeParseReturnType<unknown, O>;
 
 export function parsingMiddleware<T, O>(
   fn: (input: T) => Promise<O>,
-  parser: ZodType<T>,
+  parser: ZodType<T, ZodTypeDef, unknown>,
   unexpectedErrorHandler?: UnexpectedErrorHandler
 ): RequestHandler;
 
@@ -24,7 +24,7 @@ export function parsingMiddleware<O>(
 
 export function parsingMiddleware<T, O>(
   fn: (input?: T) => Promise<O>,
-  parser: ZodType<T> | undefined | CustomParsingFunction<T>,
+  parser: ZodType<T, ZodTypeDef, unknown> | undefined | CustomParsingFunction<T>,
   unexpectedErrorHandler?: UnexpectedErrorHandler,
 ): RequestHandler {
   _validateParser(parser);
@@ -59,7 +59,7 @@ function _validateParser(parser: ZodType | CustomParsingFunction<unknown> | unde
   }
 }
 
-async function _parseRequest<T>(parser: ZodType<T> | CustomParsingFunction<T>, req: Request): Promise< SafeParseReturnType<unknown, T>> {
+async function _parseRequest<T>(parser: ZodType<T, ZodTypeDef, unknown> | CustomParsingFunction<T>, req: Request): Promise< SafeParseReturnType<unknown, T>> {
   if (parser instanceof ZodType) {
     return parser.safeParse({ ...req.params, ...req.body });
   }

--- a/tests/integration-test.spec.ts
+++ b/tests/integration-test.spec.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { initServer } from  './test-server';
-import { parsingMiddleware } from '../src/zodExpressLite';
+import { parsingMiddleware } from '../src';
 import { Application, Request } from 'express';
 import z from 'zod';
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';

--- a/tests/zod-support.spec.ts
+++ b/tests/zod-support.spec.ts
@@ -1,0 +1,27 @@
+import { parsingMiddleware } from '../src';
+import { z } from 'zod';
+import { describe, it } from 'vitest';
+
+describe('Zod support', () => {
+  it('Should support zod.preprorcess', () => {
+    const User = z.object({
+      id: z.preprocess((val) => {
+        if (typeof val === 'string') {
+          return parseInt(val);
+        }
+        return val;
+      }, z.number())
+    });
+    type User = z.infer<typeof User>;
+    parsingMiddleware(async (user: User) => user, User);
+  });
+
+  it('Should support zod.coerce', () => {
+    const User = z.object({
+      id: z.coerce.number()
+    });
+    type User = z.infer<typeof User>;
+    parsingMiddleware(async (user: User) => user, User);
+  });
+});
+


### PR DESCRIPTION
The type result of z.preprocess is not assignable to the inferred type,
causing the code to not compile. Maybe we shouldn't use ZodType?
